### PR TITLE
Quest Tracker View와 Player의 Status

### DIFF
--- a/Assets/01.Scenes/001_BuildScene/Dongon1.unity
+++ b/Assets/01.Scenes/001_BuildScene/Dongon1.unity
@@ -222,6 +222,10 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1278026075}
     m_Modifications:
+    - target: {fileID: 69680836, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
+      propertyPath: questTitle
+      value: 
+      objectReference: {fileID: 3923936426391139786, guid: 5a7945e069974114da69ea4523bc6181, type: 3}
     - target: {fileID: 3083277524429881940, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -7997,6 +8001,10 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1278026075}
     m_Modifications:
+    - target: {fileID: 69680836, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
+      propertyPath: questTitle
+      value: 
+      objectReference: {fileID: 3923936426391139786, guid: 5a7945e069974114da69ea4523bc6181, type: 3}
     - target: {fileID: 3083277524429881940, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -8376,8 +8384,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ccf8cdb7a75223f47a5dcbd5c7da16a4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  activeQuests:
-  - {fileID: 11400000, guid: 0924ccf6e514e6449b019c666196ff83, type: 2}
+  activeQuests: []
   completedQuests: []
   activeAchievement: []
   completedAchievements: []
@@ -8394,7 +8401,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 24
+  m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &984576924
 GameObject:
@@ -8539,6 +8546,10 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1278026075}
     m_Modifications:
+    - target: {fileID: 69680836, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
+      propertyPath: questTitle
+      value: 
+      objectReference: {fileID: 3923936426391139786, guid: 5a7945e069974114da69ea4523bc6181, type: 3}
     - target: {fileID: 3083277524429881940, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -8817,6 +8828,10 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1278026075}
     m_Modifications:
+    - target: {fileID: 69680836, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
+      propertyPath: questTitle
+      value: 
+      objectReference: {fileID: 3923936426391139786, guid: 5a7945e069974114da69ea4523bc6181, type: 3}
     - target: {fileID: 3083277524429881940, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -9185,6 +9200,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   thisRect: {fileID: 1278026075}
+  viewQuest:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 11400000, guid: d8b32670c3986cb4b8281b3a9bd43776, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
   viewContainer:
   - {fileID: 69680836}
   - {fileID: 667244314}
@@ -9447,6 +9468,56 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!1 &1355722938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1355722940}
+  - component: {fileID: 1355722939}
+  m_Layer: 0
+  m_Name: QuestGiver
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1355722939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355722938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76dccb330b6cde2468064e987404bdfa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  quests:
+  - {fileID: 11400000, guid: 0924ccf6e514e6449b019c666196ff83, type: 2}
+  - {fileID: 11400000, guid: 0924ccf6e514e6449b019c666196ff83, type: 2}
+  - {fileID: 11400000, guid: d8b32670c3986cb4b8281b3a9bd43776, type: 2}
+  - {fileID: 11400000, guid: 63cd1c7a646b2c8439131f120c14ef3f, type: 2}
+  - {fileID: 11400000, guid: 63cd1c7a646b2c8439131f120c14ef3f, type: 2}
+--- !u!4 &1355722940
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355722938}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 15.123594, y: 0.5828872, z: 3.8796089}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1597614934
 GameObject:
   m_ObjectHideFlags: 0
@@ -10634,6 +10705,10 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1278026075}
     m_Modifications:
+    - target: {fileID: 69680836, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
+      propertyPath: questTitle
+      value: 
+      objectReference: {fileID: 3923936426391139786, guid: 5a7945e069974114da69ea4523bc6181, type: 3}
     - target: {fileID: 3083277524429881940, guid: 46233c19dad8b5c46a8834785721ba93, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0

--- a/Assets/02.Script/GameManager/GameManager.cs
+++ b/Assets/02.Script/GameManager/GameManager.cs
@@ -10,6 +10,8 @@ public class GameManager : MonoBehaviour
     private StatusUIManager statusUI;
     [SerializeField]
     private ItemStatus itemStatus;
+    [SerializeField]
+    private PlayerSaveStatus playerSaveStatus;
 
     public int level;
     public int health;
@@ -36,7 +38,8 @@ public class GameManager : MonoBehaviour
             Destroy(this.gameObject);
         }
 
-        FirstStart();
+        playerSaveStatus.FirstStart();
+        isStart = true;
 
         SceneManager.sceneLoaded += OnSceneLoad;
     }
@@ -58,7 +61,7 @@ public class GameManager : MonoBehaviour
 
     private void FirstStart()
     {
-        level = 1;
+        level = playerSaveStatus.Level;
         health = 5;
         str = 5;
         dex = 5;
@@ -105,9 +108,21 @@ public class GameManager : MonoBehaviour
         statusUI.ViewAndHideStateButton();
     }
 
+    private void GetPlayerStatus()
+    {
+        level = playerSaveStatus.Level;
+        health = playerSaveStatus.Health;
+        str = playerSaveStatus.Str;
+        dex = playerSaveStatus.Dex;
+        luk = playerSaveStatus.Luk;
+        bonusState = playerSaveStatus.BonusStatus;
+    }
+
     public void ChangePlayerStatus()
     {
-        var player = PlayerStatus.instance;        
+        var player = PlayerStatus.instance;
+
+        GetPlayerStatus();
 
         player.Level = level;
         player.MaxHP = (health * 20) + (str * 5) + itemStatus.ItemHP;
@@ -129,6 +144,8 @@ public class GameManager : MonoBehaviour
 
         ChangeHPBar();
     }
+
+    public void PlayerStatusUp(string status) => playerSaveStatus.StatusUP(status);
 
     public void PlayerWeaponChange(WeaponItem item) => itemStatus.ChangeWeaponItem(item);
     public void PlayerArmorChange(ArmorItem item) => itemStatus.ChangeArmorItem(item);

--- a/Assets/02.Script/GameManager/PlayerSaveStatus.cs
+++ b/Assets/02.Script/GameManager/PlayerSaveStatus.cs
@@ -1,0 +1,105 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerSaveStatus : MonoBehaviour
+{
+    [SerializeField]
+    private int level;
+    [SerializeField]
+    private int health;
+    [SerializeField]
+    private int str;
+    [SerializeField]
+    private int dex;
+    [SerializeField]
+    private int luk;
+    [SerializeField]
+    private int bonusState;
+    [SerializeField]
+    private int exp;
+    [SerializeField]
+    private int currentExp;
+
+    public int Level => level;
+    public int Health => health;
+    public int Str => str;
+    public int Dex => dex;
+    public int Luk => luk;
+    public int BonusStatus => bonusState;
+    public int Exp => exp;
+    public int CurrentExp => currentExp;
+
+    public void FirstStart()
+    {
+        level = 1;
+        health = 5;
+        str = 5;
+        dex = 5;
+        luk = 5;
+        bonusState = 0;
+
+        exp = 200;
+        currentExp = 0;
+    }
+
+    public void StatusUP(string status)
+    {
+        bool useState = false;
+
+        if (bonusState >= 1)
+        {
+            switch (status)
+            {
+                case "health":
+                    health++;
+                    useState = true;
+                    break;
+                case "str":
+                    str++;
+                    useState = true;
+                    break;
+                case "dex":
+                    dex++;
+                    useState = true;
+                    break;
+                case "luk":
+                    luk++;
+                    useState = true;
+                    break;
+                default:
+                    useState = false;
+                    break;
+            }
+
+            if (useState)
+            {
+                bonusState--;
+                GameManager.instance.ChangePlayerStatus();
+            }
+            else
+                Debug.Log("Can't use bonus status");
+        }
+    }
+
+    public void GetExp(int getExp)
+    {
+        if (level <= 100)
+        {
+            currentExp += getExp;
+
+            while (currentExp >= exp)
+            {
+                currentExp -= exp;
+
+                exp = exp + (level * 50) + 150;
+
+                level++;
+                bonusState += 5;
+            }
+
+            GameManager.instance.ChangeExpBar();
+        }
+    }
+
+}

--- a/Assets/02.Script/GameManager/PlayerSaveStatus.cs.meta
+++ b/Assets/02.Script/GameManager/PlayerSaveStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f750a8473cd640a478f2a71902315a3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/02.Script/GameManager/Save/SaveData.cs
+++ b/Assets/02.Script/GameManager/Save/SaveData.cs
@@ -24,4 +24,7 @@ public class SaveData
 
     public int exp;
     public int currentExp;
+
+    public List<Quest> activeQuest = new List<Quest>();
+    public List<Quest> completedQuest = new List<Quest>();
 }

--- a/Assets/02.Script/Player/PlayerStatus.cs
+++ b/Assets/02.Script/Player/PlayerStatus.cs
@@ -110,6 +110,7 @@ public class PlayerStatus : MonoBehaviour
                 exp = exp + (level * 50) + 150;
 
                 GameManager.instance.LevelUP();
+                Debug.Log("Player Status LevelUp");
             }
 
             GameManager.instance.ChangeExpBar();

--- a/Assets/02.Script/Quest/QuestGiver.cs
+++ b/Assets/02.Script/Quest/QuestGiver.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class QuestGiver : MonoBehaviour
+{
+    [SerializeField]
+    private Quest[] quests;
+
+    private void Start()
+    {
+        foreach(var quest in quests)
+        {
+            QuestSystem.instance.QuestSystemRegister(quest);
+        }
+    }
+}

--- a/Assets/02.Script/Quest/QuestGiver.cs.meta
+++ b/Assets/02.Script/Quest/QuestGiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76dccb330b6cde2468064e987404bdfa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/02.Script/Ui/QuestUI/ListView/QuestListContentController.cs
+++ b/Assets/02.Script/Ui/QuestUI/ListView/QuestListContentController.cs
@@ -12,20 +12,20 @@ public class QuestListContentController : MonoBehaviour
     private QuestListContainer containerPrefab;
 
     // 사용 방법 대충 알겠지만, 정리 필요
-    private Dictionary<Quest, GameObject> elemetQuests = new Dictionary<Quest, GameObject>();
+    private Dictionary<Quest, GameObject> elementQuests = new Dictionary<Quest, GameObject>();
 
     public void AddElement(Quest quest)
     {
         var element = Instantiate(containerPrefab, content.transform);
         element.UpdateQuestList(quest);
 
-        elemetQuests.Add(quest, element.gameObject);
+        elementQuests.Add(quest, element.gameObject);
     }
 
     public void RemoveElement(Quest quest)
     {
-        Destroy(elemetQuests[quest]);
-        elemetQuests.Remove(quest);
+        Destroy(elementQuests[quest]);
+        elementQuests.Remove(quest);
     }
 
     public void UpdateQuestListContentSize()

--- a/Assets/02.Script/Ui/QuestUI/TrackerView/QuestTrackerView.cs
+++ b/Assets/02.Script/Ui/QuestUI/TrackerView/QuestTrackerView.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class QuestTrackerView : MonoBehaviour
@@ -7,28 +8,40 @@ public class QuestTrackerView : MonoBehaviour
     [SerializeField]
     private RectTransform thisRect;
     [SerializeField]
+    private List<Quest> viewQuest = new List<Quest>();
+    [SerializeField]
     private List<TrackerViewContainer> viewContainer = new List<TrackerViewContainer>();
 
     private int questIndex;
 
     public void TrackerViewStart()
     {
-        questIndex = 0;
+        // viewQuest에서 null일 경우 삭제        
+        List<Quest> sortQuest = viewQuest.Where(x => x != null).ToList();
 
-        for(int i = 0; i < 5; i++)
+        viewQuest = sortQuest;
+
+        if(viewQuest.Count <= 5)
         {
-            if (viewContainer[i].gameObject.activeSelf)
+            int addIndex = 5 - viewQuest.Count;
+
+            for(int i = 0; i < addIndex; i++)
             {
-                viewContainer[i].TrackerViewContainerStart();
-            }                
+                viewQuest.Add(null);
+            }
         }
 
+        int questIndex = 0;
         for (int i = 0; i < 5; i++)
         {
             if (viewContainer[i].gameObject.activeSelf)
             {
-                questIndex++;
-            }
+                Quest getQuest = null;
+                if (viewQuest[questIndex] != null)
+                    getQuest = viewQuest[questIndex++];
+
+                 viewContainer[i].SetTrackerView(getQuest);
+            }                
         }
 
         SetTrackerViewSize();
@@ -36,27 +49,37 @@ public class QuestTrackerView : MonoBehaviour
     
     public void QuestInputToTrackerView(Quest quest)
     {
-        if (questIndex >= 5)
-            return;
+        questIndex = -1;
+        for(int i =0; i < 5; i++)
+        {
+            if (!this.transform.GetChild(i).gameObject.activeSelf)
+            {
+                questIndex = i;
+                break;
+            }       
+        }
 
-        questIndex++;
+        if(questIndex <= -1)
+        {
+            return;
+        }
+
         viewContainer[questIndex].gameObject.SetActive(true);
         viewContainer[questIndex].SetTrackerView(quest);
+
+        viewQuest[questIndex] = quest;
 
         SetTrackerViewSize();
     }
 
     public void QuestRemoveToTrackerView(Quest quest)
     {
-        int removeIndex = 0;
-
         for(int i = 0; i < 5; i++)
         {
             if(viewContainer[i].InputQuest == quest)
             {
                 viewContainer[i].RemoveTrackerView();
-                removeIndex = i;
-                questIndex--;
+                viewQuest[i] = null;
 
                 break;
             }

--- a/Assets/02.Script/Ui/QuestUI/TrackerView/TrackerViewContainer.cs
+++ b/Assets/02.Script/Ui/QuestUI/TrackerView/TrackerViewContainer.cs
@@ -27,9 +27,17 @@ public class TrackerViewContainer : MonoBehaviour
 
     public void SetTrackerView(Quest quest)
     {
+        if (quest == null)
+        {
+            TrackerViewContainerStart();
+            return;
+        }
+            
+
         inputQuest = quest;
 
-        questTitle.text = inputQuest.DisplayName;
+        var newQuestTitle = Instantiate(questTitle, thisRect);
+        newQuestTitle.text = $" {inputQuest.DisplayName}";
 
         foreach(var taskGroup in inputQuest.TaskGroups)
         {
@@ -39,6 +47,8 @@ public class TrackerViewContainer : MonoBehaviour
                 newTrackerTask.UpdateTaskText(task);
             }
         }
+
+        newQuestTitle.transform.SetAsFirstSibling();
 
         SetTrackerViewContainerSize();
     }
@@ -61,9 +71,12 @@ public class TrackerViewContainer : MonoBehaviour
 
     private void SetTrackerViewContainerSize()
     {
-        float rectHeight = 40.0f;
+        float rectHeight = 0.0f;
 
-        for(int i = 0; i < this.gameObject.transform.childCount; i++)
+        if(this.transform.childCount > 0)
+            rectHeight = 40.0f;
+
+        for (int i = 0; i < this.gameObject.transform.childCount - 1; i++)
         {
             rectHeight += 30.0f;
         }

--- a/Assets/02.Script/Ui/Status/StatusUIManager.cs
+++ b/Assets/02.Script/Ui/Status/StatusUIManager.cs
@@ -158,6 +158,12 @@ public class StatusUIManager : MonoBehaviour
 
     private void StatusUP(string status)
     {
+        GameManager.instance.PlayerStatusUp(status);
+        ViewAndHideStateButton();
+    }
+
+/*    private void StatusUP(string status)
+    {
         var gameManager = GameManager.instance;
         bool useState = false;
 
@@ -197,5 +203,5 @@ public class StatusUIManager : MonoBehaviour
         }
         else
             ViewAndHideStateButton();
-    }
+    }*/
 }

--- a/Assets/04.Prefabs/GameManager/GameManager.prefab
+++ b/Assets/04.Prefabs/GameManager/GameManager.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7999022074942841833}
   - component: {fileID: 7999022074942841834}
+  - component: {fileID: 7951307945854060596}
   - component: {fileID: 7999022074942841835}
   - component: {fileID: 7999022074942841836}
   - component: {fileID: 1057770570}
@@ -33,7 +34,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7999022074942841834
 MonoBehaviour:
@@ -49,12 +50,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   statusUI: {fileID: 0}
   itemStatus: {fileID: 7999022074942841835}
+  playerSaveStatus: {fileID: 0}
   level: 0
   health: 0
   str: 0
   dex: 0
   luk: 0
   bonusState: 0
+--- !u!114 &7951307945854060596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7999022074942841837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f750a8473cd640a478f2a71902315a3d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  level: 0
+  health: 0
+  str: 0
+  dex: 0
+  luk: 0
+  bonusState: 0
+  exp: 0
+  currentExp: 0
 --- !u!114 &7999022074942841835
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -137,6 +159,8 @@ MonoBehaviour:
     currnetHP: 0
     exp: 0
     currentExp: 0
+    activeQuest: []
+    completedQuest: []
   invenItemDatabase: {fileID: 0}
   weaponItemDatabase: {fileID: 0}
   armorItemDatabase: {fileID: 0}

--- a/Assets/04.Prefabs/Quest/Quests/Quest_KillOrcs2.asset
+++ b/Assets/04.Prefabs/Quest/Quests/Quest_KillOrcs2.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   category: {fileID: 11400000, guid: d022e4465de60e543a90de11315cdeb9, type: 2}
   icon: {fileID: 21300000, guid: a90a16980323b4c019b887093825bda3, type: 3}
   codeName: Killing orcs season2.
-  displayName: 
+  displayName: "\uC624\uD06C \uCC98\uCE58\uD558\uAE30 2"
   desctiption: Killing the Orc
   taskGroups:
   - tasks:

--- a/Assets/04.Prefabs/Quest/Quests/Quest_KillOrcs3.asset
+++ b/Assets/04.Prefabs/Quest/Quests/Quest_KillOrcs3.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   category: {fileID: 11400000, guid: d022e4465de60e543a90de11315cdeb9, type: 2}
   icon: {fileID: 21300000, guid: a90a16980323b4c019b887093825bda3, type: 3}
   codeName: Killing orcs season2.
-  displayName: 
+  displayName: "\uC624\uD06C \uCC98\uCE58\uD558\uAE30 3"
   desctiption: Killing the Orc
   taskGroups:
   - tasks:

--- a/Assets/04.Prefabs/UI/Quest/TrackerView/QuestTitle.prefab
+++ b/Assets/04.Prefabs/UI/Quest/TrackerView/QuestTitle.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3747033065887322217
+--- !u!1 &7558341264701452193
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,114 +8,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7000347860696562778}
-  - component: {fileID: 302197531397868708}
-  - component: {fileID: 5758708419134926718}
+  - component: {fileID: 8669860334239632078}
+  - component: {fileID: 256395170425586344}
+  - component: {fileID: 3923936426391139786}
   m_Layer: 5
-  m_Name: TrackerViewTask
+  m_Name: QuestTitle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &7000347860696562778
+--- !u!224 &8669860334239632078
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3747033065887322217}
+  m_GameObject: {fileID: 7558341264701452193}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7505624055824136924}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 390, y: 30}
+  m_SizeDelta: {x: 300, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &302197531397868708
+--- !u!222 &256395170425586344
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3747033065887322217}
+  m_GameObject: {fileID: 7558341264701452193}
   m_CullTransparentMesh: 1
---- !u!114 &5758708419134926718
+--- !u!114 &3923936426391139786
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3747033065887322217}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7c232dfed7b475a4a9144d293010503e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  normalColor: {r: 0.990566, g: 0.990566, b: 0.990566, a: 1}
-  completeColor: {r: 0, g: 0.7264151, b: 0.01345208, a: 1}
-  successCountColor: {r: 1, g: 0, b: 0, a: 1}
-  taskText: {fileID: 6729712852149091546}
---- !u!1 &7763747024570344855
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7505624055824136924}
-  - component: {fileID: 7907723605808487835}
-  - component: {fileID: 6729712852149091546}
-  m_Layer: 5
-  m_Name: TaskText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7505624055824136924
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7763747024570344855}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7000347860696562778}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 370, y: 30}
-  m_Pivot: {x: 1, y: 0.5}
---- !u!222 &7907723605808487835
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7763747024570344855}
-  m_CullTransparentMesh: 1
---- !u!114 &6729712852149091546
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7763747024570344855}
+  m_GameObject: {fileID: 7558341264701452193}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
@@ -129,7 +66,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uD14C\uC2A4\uD06C\uD14C\uC2A4\uD06C\uD14C\uC2A4\uD06C\uD14C\uC2A4\uD06C\uD14C\uC2A4\uD06C\uD14C\uC2A4\uD06C\uD14C\uC2A4\uD06C"
+  m_text: "\uD018\uC2A4\uD2B8 \uC774\uB984"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 48dc5f129da132f46b5420ed0fd96587, type: 2}
   m_sharedMaterial: {fileID: -8571804404549653356, guid: 48dc5f129da132f46b5420ed0fd96587, type: 2}
@@ -156,15 +93,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 22
-  m_fontSizeBase: 22
+  m_fontSize: 32
+  m_fontSizeBase: 32
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/04.Prefabs/UI/Quest/TrackerView/QuestTitle.prefab.meta
+++ b/Assets/04.Prefabs/UI/Quest/TrackerView/QuestTitle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5a7945e069974114da69ea4523bc6181
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04.Prefabs/UI/Quest/TrackerView/TrackerViewContainer.prefab
+++ b/Assets/04.Prefabs/UI/Quest/TrackerView/TrackerViewContainer.prefab
@@ -1,140 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4215113945691219771
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3083277524429881940}
-  - component: {fileID: 5842697674026601010}
-  - component: {fileID: 7273058291126566224}
-  m_Layer: 5
-  m_Name: QuestTitle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &3083277524429881940
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4215113945691219771}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3473339886346669689}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 300, y: 40}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5842697674026601010
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4215113945691219771}
-  m_CullTransparentMesh: 1
---- !u!114 &7273058291126566224
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4215113945691219771}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "\uD018\uC2A4\uD2B8 \uC774\uB984"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 48dc5f129da132f46b5420ed0fd96587, type: 2}
-  m_sharedMaterial: {fileID: -8571804404549653356, guid: 48dc5f129da132f46b5420ed0fd96587, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 32
-  m_fontSizeBase: 32
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 1
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5066369348130516620
 GameObject:
   m_ObjectHideFlags: 0
@@ -166,8 +31,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3083277524429881940}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -253,5 +117,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   thisRect: {fileID: 3473339886346669689}
-  questTitle: {fileID: 7273058291126566224}
+  questTitle: {fileID: 3923936426391139786, guid: 5a7945e069974114da69ea4523bc6181, type: 3}
   taskPrefab: {fileID: 5758708419134926718, guid: f4a7eee28037ab04a88fc0794806e4f5, type: 3}


### PR DESCRIPTION
Quest Tracker View
 - 기존에 저장 된 데이터가 있을 경우, 정렬하여 순서대로 보이도록 변경
 - 허나 저장 된 데이터가 있을 시, Quest List View의 버튼이 표시되지 않아 수정 필요
 
 Player의 Status 저장 방식 변경 중
 - 일일이 SaveDatabase를 보면 저장 할 값들을 일일이 저장했지만, 저장할 값들을 하나의 class를 만들어서 저장할 계획